### PR TITLE
Fixed reference to Handlebars.registerHelper.

### DIFF
--- a/src/pages/index.haml
+++ b/src/pages/index.haml
@@ -391,7 +391,7 @@
   .bullet
     .description
       Handlebars helpers can be accessed from any context in a template.
-      You can register a helper with the Handlebars.registerHElper method.
+      You can register a helper with the <code>Handlebars.registerHelper</code> method.
     :html
       <div class="post">
         <h1>By {{fullName author}}</h1>


### PR DESCRIPTION
Fixed capitalization and wrapped in a code tag.
