### PR TITLE
Fixed nested path template.

### DIFF
--- a/src/pages/index.haml
+++ b/src/pages/index.haml
@@ -340,11 +340,12 @@
     :html
       <div class="entry">
         <h1>{{title}}</h1>
-        <h2>By {{author/name}}</h2>
+        <h2>By {{author.name}}</h2>
 
         <div class="body">
           {{body}}
         </div>
+      </div>
     .notes
       That template works with this context
     :javascript


### PR DESCRIPTION
Use `.` instead of deprecated `/` for nested paths.

Added missing closing div.
