### PR TITLE
Added clarification to the handlebars website's helpers section for the sake of beginners

### DIFF
--- a/src/pages/expressions.haml
+++ b/src/pages/expressions.haml
@@ -57,7 +57,7 @@
   .bullet
     .description
       A Handlebars helper call is a simple identifier, followed by
-      zero or more parameters. Each parameter is a Handlebars
+      zero or more parameters (separated by space). Each parameter is a Handlebars
       expression.
     :html
       {{{link story}}}


### PR DESCRIPTION
... understand that parameters in helpers are separated with spaces :)
