### PR TITLE
Extra '{' in block_helpers page

### DIFF
--- a/src/pages/block_helpers.haml
+++ b/src/pages/block_helpers.haml
@@ -100,7 +100,7 @@
         {{#each comments}}
           <div class="comment">
             <h2>{{subject}}</h2>
-            {{{{body}}}
+            {{{body}}}
           </div>
         {{/each}}
       </div>


### PR DESCRIPTION
Block Helpers page, under 'simple iterators' had an extra '{'
