### PR TITLE
Add runtime download link to the home page

### DIFF
--- a/src/pages/index.haml
+++ b/src/pages/index.haml
@@ -9,6 +9,7 @@
     taking advantage of the extra Handlebars features.
 
 = link("Download: 1.0.rc.1", "https://github.com/downloads/wycats/handlebars.js/handlebars-1.0.rc.1.js", :class => 'download')
+= link("Download: runtime-1.0.rc.1", "https://github.com/downloads/wycats/handlebars.js/handlebars.runtime-1.0.rc.1.min.js", :class => 'download-runtime')
 
 %h2#getting-started
   Getting Started

--- a/src/stylesheets/application.sass
+++ b/src/stylesheets/application.sass
@@ -77,6 +77,9 @@ a.download
   +linear-gradient(color_stops($gradient-top, $gradient-bottom))
   +border-radius(5px)
 
+a.download-runtime
+  text-align: center
+
 .intro
   width: 100%
 


### PR DESCRIPTION
I can't figure out what environment your site runs in, so the style for the new download link may need to be tweaked by someone who can run it. It should be a simple link centered directly under the current download button.
