### PR TITLE
document {{@index}} and {{@key}} for use within {{#each}} blocks

### DIFF
--- a/src/pages/index.haml
+++ b/src/pages/index.haml
@@ -292,6 +292,23 @@
         <p class="empty">No content</p>
       {{/each}}
 
+  .bullet
+    .description
+      When looping through items in <code>each</code>, you can optionally reference the current loop index via <code>{{@index}}</code>
+
+    :html
+      {{#each array}}
+        {{@index}}: {{this}}
+      {{/each}}
+
+    .notes
+      For object iteration, use <code>{{@key}}</code> instead:
+
+    :html
+      {{#each object}}
+        {{@key}}: {{this}}
+      {{/each}}
+
 %h2#conditionals
   The <code>if</code> block helper
 


### PR DESCRIPTION
add documentation note about the ability to use {{@index}} and {{@key}} within each blocks
