### PR TITLE
Update SC.keys reference to Em.keys

### DIFF
--- a/src/pages/block_helpers.haml
+++ b/src/pages/block_helpers.haml
@@ -245,7 +245,7 @@
       hash arguments.
     :javascript
       Handlebars.registerHelper('list', function(context, options) {
-        var attrs = SC.keys(options.hash).map(function(key) {
+        var attrs = Em.keys(options.hash).map(function(key) {
           key + '="' + options.hash[key] + '"';
         }).join(" ");
 


### PR DESCRIPTION
Most devs aren't likely to be using SproutCore at this point. Update `#keys` reference to the short form of Ember.
