### PR TITLE
Corrected Muctache compatibility statement.

### DIFF
--- a/src/pages/index.haml
+++ b/src/pages/index.haml
@@ -4,9 +4,9 @@
     <strong>semantic templates</strong> effectively with no frustration.
 
   %p
-    Mustache templates are compatible with Handlebars, so you can
-    take a Mustache template, import it into Handlebars, and start
-    taking advantage of the extra Handlebars features.
+    Handlebars is mostly compatible with Mustache templates. For 
+    an insight into some of the incompatible features see 
+    <a href="https://github.com/wycats/handlebars.js/issues/148">This issue</a>.
 
 = link("Download: 1.3.0", "http://builds.handlebarsjs.com.s3.amazonaws.com/handlebars-v1.3.0.js", :class => 'download')
 = link("Download: runtime-1.3.0", "http://builds.handlebarsjs.com.s3.amazonaws.com/handlebars.runtime-v1.3.0.js", :class => 'download-runtime')


### PR DESCRIPTION
Currently handlebars in not compliant with Mustache and this should be accurately represented. This relates to [issue #148](https://github.com/wycats/handlebars.js/issues/148) in the Handlebars repo.
