### PR TITLE
fixed img alt tag

### DIFF
--- a/src/layouts/default.haml
+++ b/src/layouts/default.haml
@@ -9,7 +9,7 @@
     #body
       #header
         %a{:href => "/"}
-          = img("handlebars_logo.png", :alt => "The best way to manage your application's dependencies")
+          = img("handlebars_logo.png", :alt => "Handlebars.js: Minimal Templating on Steroids")
       #contents
         %a#callout{:href => "http://www.devswag.com/collections/handlebars"}
           = img("handlebars-devswag.png", :alt => "Buy Handlebars swag on DevSwag!")


### PR DESCRIPTION
I googled for "handlebars dependencies" and google responded with your site and the following description: "The best way to manage your application's dependencies ... Handlebars provides the power necessary to let you build semantic templates effectively with no ..."

A quick look in the source revealed that the img tag was having the wrong alt tag, probably the one from http://bundler.io/
