### PR TITLE
Fix typo in raw-blocks section

### DIFF
--- a/src/pages/block_helpers.haml
+++ b/src/pages/block_helpers.haml
@@ -339,7 +339,7 @@
         {{{/raw-helper}}}
 
       .notes
-        will execute the helper <code>foo</code> without interpretting the content.
+        will execute the helper <code>raw-helper</code> without interpretting the content.
 
       :javascript
         Handlebars.registerHelper('raw-helper', function(options) {


### PR DESCRIPTION
The notes for the `{{{raw-helper}}}` section seem to be incorrect
