### PR TITLE
Document "preventIndent" option

### DIFF
--- a/src/pages/reference.haml
+++ b/src/pages/reference.haml
@@ -41,6 +41,11 @@
           <code>strict</code>: Run in strict mode. In this mode, templates will throw rather than silently ignore missing fields. This has the side effect of disabling inverse operatins such as <code>{{^foo}}{{/foo}}</code> unless fields are explicitly included in the source object.
         %li
           <code>assumeObjects</code>: Removes object existence checks when traversing paths. This is a subset of <code>strict</code> mode that generates optimized templates when the data inputs are known to be safe.
+        %li
+          <code>preventIndent</code>: By default an indented partial-call causes the output of the 
+          whole partial being indented by the same amount. This leads to unexpected behavior when the
+          partial writes <code>pre</code>-tags. 
+          Setting this option to <code>true</code> will disable the auto-indent feature.
 
 %h3#base-precompile
   %code Handlebars.precompile(template, options)


### PR DESCRIPTION
I found out about the "preventIndent" option via issue wycats/handlebars.js#858, but it would have saved me some time if it would have been documented. So here is a proposal for documentation. I hope I got the markup right.