### PR TITLE
Update reference to Homebrew installation

### DIFF
--- a/src/pages/precompilation.haml
+++ b/src/pages/precompilation.haml
@@ -9,15 +9,13 @@
 .contents
   .bullet
     .description
-      First, you will need to install node and npm. On OSX:
+      First, you will need to install node and npm. On OS X:
 
     :highlight_plain
       $ brew install node
     .notes
       This assumes you already have Homebrew installed. If not,
-      install it first.
-    :highlight_plain
-      $ /usr/bin/ruby -e "$(curl -fsSL https://raw.github.com/mxcl/homebrew/go)"
+      <a href="http://brew.sh/">install it</a> first.
 
   .bullet
     .description


### PR DESCRIPTION
I think it's best if we link to the Homebrew site for installation instructions so we don't have to maintain it.