### PR TITLE
Fixes a typo in each helper documentation

### DIFF
--- a/src/pages/builtin_helpers.haml
+++ b/src/pages/builtin_helpers.haml
@@ -125,7 +125,7 @@
 
     .notes
       The first and last steps of iteration are noted via the <code>@first</code> and <code>@last</code>
-      variables then iterating over an array. When iterating over an object only the <code>@first</code>
+      variables when iterating over an array. When iterating over an object only the <code>@first</code>
       is available.
 
     .notes


### PR DESCRIPTION
"then iterating" => "when iterating"