### PR TITLE
Fix typo/grammer in builtin_helpers.md

### DIFF
--- a/src/pages/builtin_helpers.haml
+++ b/src/pages/builtin_helpers.haml
@@ -129,7 +129,7 @@
       is available.
 
     .notes
-      Nested <code>each</code> blocks may access the interation variables via depted paths.
+      Nested <code>each</code> blocks may access the interation variables via depth based paths.
       To access the parent index, for example, <code>{{@../index}}</code> can be used.
 
 %h2#with


### PR DESCRIPTION
Fixed an issue where there was a typo, or strange grammar, in `src/pages/builtin_helpers.md`. Super small change.

Please forgive my ignorance if "depted" is a word I am not familiar with!