### PR TITLE
Fixes comments code sample

### DIFF
--- a/src/pages/index.haml
+++ b/src/pages/index.haml
@@ -304,7 +304,7 @@
       <div class="entry">
         {{!-- only output author name if an author exists --}}
         {{#if author}}
-          <h1>{{firstName}} {{lastName}}</h1>
+          <h1>{{author.firstName}} {{author.lastName}}</h1>
         {{/if}}
       </div>
     .notes


### PR DESCRIPTION
I believe the original is erroneous, as `{{#if}}` does not change the context.