### PR TITLE
Fixed incorrect '#each as' documentation to remove incorrect ','

### DIFF
--- a/src/pages/builtin_helpers.haml
+++ b/src/pages/builtin_helpers.haml
@@ -138,8 +138,8 @@
       The <code>each</code> helper also supports <a href="block_helpers.html#block-params">block parameters</a>, allowing for named references anywhere in the block.
 
     :html
-      {{#each array as |value, key|}}
-        {{#each child as |childValue, childKey|}}
+      {{#each array as |value key|}}
+        {{#each child as |childValue childKey|}}
           {{key}} - {{childKey}}. {{childValue}}
         {{/each}}
       {{/each}}


### PR DESCRIPTION
Fixed #127: 'each as' example had a ',' between the two variables e.g. 

```
{{#each array as |value, key|}}
```
 when it should be
```
{{#each array as |value key|}}
```