### PR TITLE
Replace Ember-specific reference with standard JS

### DIFF
--- a/src/pages/block_helpers.haml
+++ b/src/pages/block_helpers.haml
@@ -294,7 +294,7 @@
       hash arguments.
     :javascript
       Handlebars.registerHelper('list', function(context, options) {
-        var attrs = Em.keys(options.hash).map(function(key) {
+        var attrs = Object.keys(options.hash).map(function(key) {
           return key + '="' + options.hash[key] + '"';
         }).join(" ");
 


### PR DESCRIPTION
In reading through the documentation on [hash arguments to block helpers](http://handlebarsjs.com/block_helpers.html), I ran across a [reference to `Em.keys()`](https://github.com/wycats/handlebars-site/blob/338b3ca6f89505f8b79682922bdc564e399fc090/src/pages/block_helpers.haml#L297).

I'm using Handlebars through the [express-handlebars](https://www.npmjs.com/package/express-handlebars) package in a simple Express app, so it took some digging to figure out that `Em` is a reference to Ember.  #117 pointed me in the right direction, but I'm not _using_ Ember, so this still doesn't explain what `Em.keys()` actually does.

I tracked down the reference to commit 512f759529f166a7cefc2e58e45770703be1b284, and found a comment chain where @scottgonzalez rightly points out that [[...] more people know what Object.keys() is, since it's an actual standard [...]](https://github.com/wycats/handlebars-site/commit/512f759529f166a7cefc2e58e45770703be1b284#commitcomment-4429687).

It is also worth noting that as of now,`Ember.keys()` has been [deprecated since v1.13](https://www.emberjs.com/deprecations/v1.x/#toc_ember-keys) (released on June 12, 2015) in favour of `Object.keys()`.

This replaces the `Em.keys()` reference in the documentation with the standard `Object.keys()`.