### PR TITLE
Use https everywhere

### DIFF
--- a/src/layouts/default.haml
+++ b/src/layouts/default.haml
@@ -11,7 +11,7 @@
         %a{:href => "/"}
           = img("handlebars_logo.png", :alt => "Handlebars.js: Minimal Templating on Steroids")
       #contents
-        %a#callout{:href => "http://www.devswag.com/collections/handlebars"}
+        %a#callout{:href => "https://www.devswag.com/collections/handlebars"}
           = img("handlebars-devswag.png", :alt => "Buy Handlebars swag on DevSwag!")
         = yield
 
@@ -19,8 +19,8 @@
           Found a documentation issue? Tell us!
 
     #credits
-    %a#github{ :href => "http://github.com/wycats/handlebars.js/" }
-      %img{:src => "http://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png", :alt => "Fork me on GitHub"}
+    %a#github{ :href => "https://github.com/wycats/handlebars.js/" }
+      %img{:src => "https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png", :alt => "Fork me on GitHub"}
 
     %script
       var _gaq = _gaq || [];


### PR DESCRIPTION
To get rid of the warning icon displayed in some browsers (e.g. firefox) I replaced the three usages of http links left with https. The changed links all support ssl.